### PR TITLE
Use public network interface, install zeroconf packages for easier network configuration

### DIFF
--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -50,8 +50,8 @@ SITE
     windows (1.34.2)
       chef_handler (>= 0.0.0)
     xfs (1.1.0)
-    yum (3.2.4)
-    yum-epel (0.4.0)
+    yum (3.3.0)
+    yum-epel (0.5.1)
       yum (~> 3.0)
     yum-mysql-community (0.1.10)
       yum (>= 3.0)
@@ -59,9 +59,9 @@ SITE
 GIT
   remote: git@github.com:articlemetrics/alm_report-cookbook.git
   ref: master
-  sha: f672fc11e2fd81a304d0e68fa776bb8bdc8afcd1
+  sha: aa9ed9100a43bd80bc4d5a15b3dce8520dbd2185
   specs:
-    alm_report (0.5.6)
+    alm_report (0.5.7)
       apt (>= 0.0.0)
       capistrano (~> 0.6.0)
       database (>= 0.0.0)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,7 +122,7 @@ Vagrant.configure("2") do |config|
     provision(config, override, chef_overrides)
   end
 
-  config.vm.hostname = "alm-report.local"
+  config.vm.hostname = "alm-report"
   # Boot with a GUI so you can see the screen. (Default is headless)
   # config.vm.boot_mode = :gui
 
@@ -135,11 +135,11 @@ Vagrant.configure("2") do |config|
   # Assign this VM to a bridged network, allowing you to connect directly to a
   # network using the host's network device. This makes the VM appear as another
   # physical device on your network.
-  # config.vm.network :bridged
+  config.vm.network "public_network"
 
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
-  config.vm.network :forwarded_port, guest: 80, host: 8090 # Apache2
+  # config.vm.network :forwarded_port, guest: 80, host: 8090 # Apache2
 
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the


### PR DESCRIPTION
With two small changes we can make setting up the network interfaces easier for developers. By enabling the `public_network` interface, the VM will get an IP address via DHCP. And by installing the `avahi-daemon` and `libnss-mdns` packages, the VM uses zeroconf networking and is immediately available as `alm-report.local`. This is nicer than using a fixed IP, or editing `/etc/hosts`. Obviously this is not needed when installing in the Cloud or with larger infrastructure that uses DNS, but I don't know whether the avahi packages could do any harm in this scenario.

A side effect is that the VM becomes available in the local network, but I think that is rather a desired effect for easily demoing an app, etc. 

Also commented out port-forwarding, as it isn't needed in this scenario.
