### PR TITLE
Make sure the ALM API returns usage stats for counter and pmc

### DIFF
--- a/app/assets/javascripts/charts_impl.js
+++ b/app/assets/javascripts/charts_impl.js
@@ -30,7 +30,7 @@ function getBubbleChartOptions() {
       'PLOS Biology': {color: '1ebd21'},                // Green
       'PLOS Computational Biology': {color: '1ebd21'},  // Green
       'PLOS Genetics': {color: '1ebd21'}                // Green
-      
+
       // All other journals get the default color specified below.
     },
     colors: ['b526fb'],  // Purple
@@ -74,7 +74,7 @@ function drawArticleUsageCitationSubjectArea() {
 function drawArticleLocation() {
   var raw_data = getArticleLocationData();
   var data = new google.visualization.DataTable();
-  
+
   // Determine if we're in lat/lng mode, or just getting addresses passed to us.
   if (raw_data[0].length == 6) {
     data.addColumn('number', 'latitude', 'latitude');
@@ -116,32 +116,35 @@ function drawArticleLocation() {
 
 function drawArticleUsageAge() {
 
-  var data = new google.visualization.DataTable();
-  data.addColumn('number', 'Months');
-  data.addColumn('number', 'HTML Views');
-  data.addColumn({type: 'string', role: 'tooltip'});
-  data.addColumn('number', 'PDF Views');
-  data.addColumn({type: 'string', role: 'tooltip'});
-  data.addColumn('number', 'XML Views');
-  data.addColumn({type: 'string', role: 'tooltip'});
-  data.addRows(getArticleUsageData());
+  var chartData = getArticleUsageData();
+  if (chartData.length > 0) {
+    var data = new google.visualization.DataTable();
+    data.addColumn('number', 'Months');
+    data.addColumn('number', 'HTML Views');
+    data.addColumn({type: 'string', role: 'tooltip'});
+    data.addColumn('number', 'PDF Views');
+    data.addColumn({type: 'string', role: 'tooltip'});
+    data.addColumn('number', 'XML Views');
+    data.addColumn({type: 'string', role: 'tooltip'});
+    data.addRows(chartData);
 
-  var options = {
-    backgroundColor: '#efefef',
-    vAxis: {
-      title: 'Total Views'
-    },
-    hAxis: {
-      title: 'Months'
-    },
-    chartArea: {
-      top: 40,
-      height: "70%"
-    }
-  };
+    var options = {
+      backgroundColor: '#efefef',
+      vAxis: {
+        title: 'Total Views'
+      },
+      hAxis: {
+        title: 'Months'
+      },
+      chartArea: {
+        top: 40,
+        height: "70%"
+      }
+    };
 
-  var chart = new google.visualization.LineChart(document.getElementById('article_usage_div'));
-  chart.draw(data, options);
+    var chart = new google.visualization.LineChart(document.getElementById('article_usage_div'));
+    chart.draw(data, options);
+  }
 }
 
 function drawArticleCitationAge() {
@@ -205,7 +208,7 @@ function drawArticleSocialScatter() {
       chartArea: {
         top: 40,
         height: "70%"
-      }    
+      }
     };
 
     var chart = new google.visualization.ScatterChart(document.getElementById('social_scatter_div'));
@@ -238,7 +241,7 @@ function drawReportGraphs() {
       drawArticleUsageCitationsAge();
       drawArticleUsageMendeleyAge();
       drawArticleUsageCitationSubjectArea();
-      drawArticleLocation();      
+      drawArticleLocation();
     }
 
   } else {

--- a/lib/chart_data.rb
+++ b/lib/chart_data.rb
@@ -180,16 +180,17 @@ module ChartData
   def self.generate_data_for_usage_chart(report)
 
     # get counter and pmc usage stat data
-    counter = report.report_dois[0].alm[:counter][:events]
-    pmc = report.report_dois[0].alm[:pmc][:events]
+    # properly handle missing elements
+    counter = report.report_dois[0].alm.fetch(:counter, {}).fetch(:events, nil)
+    pmc = report.report_dois[0].alm.fetch(:pmc, {}).fetch(:events, nil)
 
-    counter_data = counter.inject({}) do | result, month_data |
+    counter_data = Array(counter).inject({}) do | result, month_data |
       month_date = Date.new(month_data["year"].to_i, month_data["month"].to_i, 1)
       result[month_date] = month_data
       result
     end
 
-    pmc_data = pmc.inject({}) do | result, month_data |
+    pmc_data = Array(pmc).inject({}) do | result, month_data |
       month_date = Date.new(month_data["year"].to_i, month_data["month"].to_i, 1)
       result[month_date] = month_data
       result

--- a/spec/lib/chart_data_spec.rb
+++ b/spec/lib/chart_data_spec.rb
@@ -20,4 +20,75 @@ describe ChartData do
       response.should be_empty
     end
   end
+
+  context "generate_data_for_usage_chart" do
+    let(:report) { OpenStruct.new(report_dois: [report_dois]) }
+    let(:data) { { "month" => "8", "year" => "2014", "html_views" => "138390", "pdf_views" => "2803", "xml_views" => "47", "full-text" => "13", "pdf" => 6 } }
+    let(:counter) { { events: [{
+      "month" => data["month"],
+      "year" => data["year"],
+      "pdf_views" => data["pdf_views"],
+      "xml_views" => data["xml_views"],
+      "html_views" => data["html_views"]
+      }]} }
+    let(:pmc) { { events: [{
+      "month" => data["month"],
+      "year" => data["year"],
+      "full-text" => data["full-text"],
+      "pdf" => data["pdf"]
+    }]} }
+    let(:html) { data["html_views"].to_i + data["full-text"].to_i }
+    let(:pdf) { data["pdf_views"].to_i + data["pdf"].to_i }
+    let(:xml) { data["xml_views"].to_i }
+    let(:usage_data) { [[0, html, "Month: 0\nHTML Views: #{html}", pdf, "Month: 0\nPDF Views: #{pdf}", xml, "Month: 0\nXML Views: #{xml}"]] }
+
+    context "full report" do
+      let(:report_dois) { OpenStruct.new(alm: { counter: counter, pmc: pmc }) }
+
+      it "should generate data" do
+        response = subject.generate_data_for_usage_chart(report)
+        response.should eq(usage_data)
+      end
+    end
+
+    context "missing counter source" do
+      let(:report_dois) { OpenStruct.new(alm: { pmc: pmc }) }
+
+      it "should generate data" do
+        response = subject.generate_data_for_usage_chart(report)
+        response.should be_empty
+      end
+    end
+
+    context "missing counter events" do
+      let(:report_dois) { OpenStruct.new(alm: { counter: {}, pmc: pmc }) }
+
+      it "should generate data" do
+        response = subject.generate_data_for_usage_chart(report)
+        response.should be_empty
+      end
+    end
+
+    context "missing pmc source" do
+      let(:report_dois) { OpenStruct.new(alm: { counter: counter }) }
+      let(:html) { data["html_views"].to_i }
+      let(:pdf) { data["pdf_views"].to_i }
+
+      it "should generate data" do
+        response = subject.generate_data_for_usage_chart(report)
+        response.should eq(usage_data)
+      end
+    end
+
+    context "missing pmc events" do
+      let(:report_dois) { OpenStruct.new(alm: { counter: counter, pmc: {} }) }
+      let(:html) { data["html_views"].to_i }
+      let(:pdf) { data["pdf_views"].to_i }
+
+      it "should generate data" do
+        response = subject.generate_data_for_usage_chart(report)
+        response.should eq(usage_data)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull requests gracefully handles situations where the ALM API returns no event data for `counter` or `pmc` and fixes #13. Added unit tests to confirm that the `generate_data_for_usage_chart` method works as expected. Also made a small tweak to the Javascript handling the missing data.
