### PR TITLE
adapt config example to changes in cookbook

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,11 +1,13 @@
 {
+  "ruby": {
+    "rails_env": "production",
+    "user": "vagrant",
+    "db": { "password": "EXAMPLE" }
+  },
   "alm_report": {
-           "rails_env": "development",
-           "deploy_user": "vagrant",
-           "db": { "password": "EXAMPLE" },
-           "settings": {
-             "url": "http://alm.plos.org",
-             "api_key": "EXAMPLE"
-           }
-         }
+    "settings": {
+      "url": "http://alm.plos.org",
+      "api_key": "EXAMPLE"
+    }
+  }
 }


### PR DESCRIPTION
The attributes in the `alm-report` cookbook have changed a bit, this fixes the configuration example.
