### PR TITLE
Precompile application layout for PLOS mode

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ AlmReport::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  config.assets.precompile += %w( charts.js print.css html5shiv.js )
+  config.assets.precompile += %w( charts.js print.css html5shiv.js application.plos.css )
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
The application layout for PLOS isn't precompiled by default. This is one possible fix. Closing #29.
