### PR TITLE
Handle session without dois

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,8 +6,8 @@ class ReportsController < ApplicationController
     dois = session[:dois]
 
     # start again if we find no dois
-    return redirect_to(controller: 'home',
-                       action: 'advanced',
+    return redirect_to(controller: "home",
+                       action: "advanced",
                        unformattedQueryId: params[:unformattedQueryId],
                        filterJournals: params[:filterJournals]) if dois.blank?
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ReportsController do
-  describe 'GET generate' do
-    it 'redirects to home for session without dois' do
+  describe "GET generate" do
+    it "redirects to home for session without dois" do
       session[:dois] = nil
       get :generate
       response.should redirect_to(controller: "home", action: "advanced")


### PR DESCRIPTION
Instead of raising an error we should redirect to the home page for a new search when a session doesn't contain at least one DOI. This closes #34. 
