### PR TITLE
use mysql cookbook with utf8 fix from article metrics repo

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -16,7 +16,7 @@ cookbook "capistrano",
 cookbook "dotenv",
   :git => "git@github.com:articlemetrics/dotenv-cookbook.git"
 cookbook "mysql",
-  git: "git@github.com:jure/mysql"
+  :git => "git@github.com:articlemetrics/mysql.git"
 cookbook 'database', '~> 2.3.0'
 cookbook "memcached"
 cookbook "phantomjs"

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -13,10 +13,10 @@ SITE
     chef_handler (1.1.6)
     chocolatey (0.2.0)
       windows (~> 1.31)
-    database (2.3.0)
+    database (2.3.1)
       aws (>= 0.0.0)
-      mysql (>= 5.0.0)
-      mysql-chef_gem (>= 0.0.0)
+      mysql (~> 5.0)
+      mysql-chef_gem (~> 0.0)
       postgresql (>= 1.0.0)
       xfs (>= 0.0.0)
     memcached (1.7.2)
@@ -40,25 +40,25 @@ SITE
       apt (>= 1.9.0)
       build-essential (>= 0.0.0)
       openssl (>= 0.0.0)
-    runit (1.5.10)
+    runit (1.5.12)
       build-essential (>= 0.0.0)
       yum (~> 3.0)
       yum-epel (>= 0.0.0)
-    windows (1.34.8)
+    windows (1.36.1)
       chef_handler (>= 0.0.0)
     xfs (1.1.0)
     yum (3.5.1)
     yum-epel (0.5.3)
       yum (~> 3.0)
-    yum-mysql-community (0.1.10)
+    yum-mysql-community (0.1.11)
       yum (>= 3.0)
 
 GIT
   remote: git@github.com:articlemetrics/alm_report-cookbook.git
   ref: master
-  sha: 9e657de9b8ae7695491b0b4646c071df6293494f
+  sha: 15528ff32412dfd5964522a912298c207d9b167f
   specs:
-    alm_report (0.6.22)
+    alm_report (0.6.23)
       apt (>= 0.0.0)
       capistrano (~> 0.7.0)
       database (>= 0.0.0)
@@ -86,6 +86,14 @@ GIT
     dotenv (0.1.7)
 
 GIT
+  remote: git@github.com:articlemetrics/mysql.git
+  ref: master
+  sha: e306cddd572ca4c1906aa533c70092528bb77532
+  specs:
+    mysql (5.6.1)
+      yum-mysql-community (>= 0.0.0)
+
+GIT
   remote: git@github.com:articlemetrics/mysql_rails-cookbook.git
   ref: master
   sha: 73dac770ec5873aa44b01c2a5342b457ec331877
@@ -98,9 +106,9 @@ GIT
 GIT
   remote: git@github.com:articlemetrics/passenger_nginx-cookbook.git
   ref: master
-  sha: 2354c9e62c5c1ae49c311b4e28581a5edb2fc682
+  sha: a53bb990328e0e920a88bce09ca06a155cfa61ec
   specs:
-    passenger_nginx (0.4.0)
+    passenger_nginx (0.4.1)
       apt (>= 0.0.0)
       ruby (~> 0.6.0)
 
@@ -111,14 +119,6 @@ GIT
   specs:
     ruby (0.6.3)
       apt (>= 0.0.0)
-
-GIT
-  remote: git@github.com:jure/mysql
-  ref: master
-  sha: 850aa16cc30cc692cdbc7e038eca33dd213a261d
-  specs:
-    mysql (5.6.1)
-      yum-mysql-community (>= 0.0.0)
 
 DEPENDENCIES
   alm_report (>= 0)


### PR DESCRIPTION
We keep all the other cookbooks needed by ALM Report also in the `articlemetrics` repo. Hopefully the upstream cookbook will be fixed soon.
